### PR TITLE
fix: recognize isDeleted flag on product seo URLs

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*.ts]
+ident_style = space
+ident_size = 2
+
+[*.js]
+indent_style = space
+indent_size = 2

--- a/fetch-fixtures.ts
+++ b/fetch-fixtures.ts
@@ -83,11 +83,16 @@ async function fetchSeoUrls(name: string) {
         },
         {
           type: "equals",
+          field: "isDeleted",
+          value: false,
+        },
+        {
+          type: "equals",
           field: "salesChannelId",
           value: salesChannel.id,
         },
       ],
-      limit: 1000,
+      limit: 500,
     },
   );
 


### PR DESCRIPTION
k6 is trying to buy products that are deleted because SEO URLs are still present, even if the product is deleted.